### PR TITLE
fix comment symbols used by built-in commands

### DIFF
--- a/package/languages/red.configuration.json
+++ b/package/languages/red.configuration.json
@@ -1,9 +1,9 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
+        "lineComment": ";",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "blockComment": [ "comment {", "}" ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
This affects the VS code commands/shortcuts that trigger a line or block
comment
