### PR TITLE
Fix typo in <kbd> close tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can also configure the directory for output files of the compiler. The curre
 
 | Key                       | Command                    | Command id      |
 | :------------------------ | -------------------------- | --------------- |
-| <kbd>F6</kdb>             | Interpret Current Red File | red.interpret   |
+| <kbd>F6</kbd>             | Interpret Current Red File | red.interpret   |
 | <kbd>F7</kbd>             | Compile Current Red File   | red.compile     |
 | <kbd>Ctrl+K Ctrl+M</kbd>  | Show Red Command Menu      | red.commandMenu |
 


### PR DESCRIPTION
Now in VS marketplace, it displays this wrong close tag.

![image](https://user-images.githubusercontent.com/3676278/36340811-e554f84c-141e-11e8-99b0-436bc8f56006.png)
