### PR TITLE
FIX: #27 red command keyboard shortcuts not working

### DIFF
--- a/src/providers/commandsProvider.ts
+++ b/src/providers/commandsProvider.ts
@@ -79,7 +79,7 @@ function execCommand(currentRedPath: string, command: string, fileUri?: vscode.U
     terminal = terminal ? terminal : vscode.window.createTerminal(`Red`);
     terminal.sendText(`cd "${redPath}"`);
 
-    if (fileUri === undefined || typeof fileUri.fsPath !== 'string') {
+    if (fileUri === null || fileUri === undefined || typeof fileUri.fsPath !== 'string') {
         const activeEditor = vscode.window.activeTextEditor;
         if (activeEditor !== undefined) {
             if (!activeEditor.document.isUntitled) {


### PR DESCRIPTION
Some internal behavioral change in VSCode makes fileUri null here. Based on behavior from the insider edition, they may be fixing this soon, but it doesn't hurt to check for null here anyway.