### PR TITLE
Adds instructions to use Red through Wine to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ You can also configure the directory for output files of the compiler. The curre
   "red.buildDir": "${workspaceRoot}/build/debug"
   ```
 
+If you are using Linux and prefer to use the Windows version of Red through Wine until GUI support is available for Linux, you can point `red.redPath` to a small [shell script](https://github.com/red/red/wiki/Visual-Studio-Code-Plugin#running-red-through-wine-on-linux).
+
 ## Shortcuts
 
 | Key                       | Command                    | Command id      |


### PR DESCRIPTION
Since Red GUI development isn't available on Linux yet, I've configured the `red.redPath` setting of the Red plugin for Visual Studio Code to point to a shell script which runs Red through Wine on Linux.

I've added instructions on how to do it including the small shell script that is needed to the [Red Wiki](https://github.com/red/red/wiki/Visual-Studio-Code-Plugin).

This pull request modifies the Readme to point to that Wiki entry so that it can be easily found.