### PR TITLE
FIX: Build output option working again

### DIFF
--- a/src/commandsProvider.ts
+++ b/src/commandsProvider.ts
@@ -151,7 +151,7 @@ export function redCompileInConsole(fileUri?: vscode.Uri) {
 	filePath = "\"" + filePath + "\"";
 
 	let command= redTool;
-	let args = "-c " + filePath + " -o " + outName;
+	let args = "-c -o " + outName + " " + filePath;
 	command = normalFile(command);
 	execCommand(command, args);
 }

--- a/src/commandsProvider.ts
+++ b/src/commandsProvider.ts
@@ -181,7 +181,7 @@ export function redCompileInGuiConsole(fileUri?: vscode.Uri) {
 	filePath = "\"" + filePath + "\"";
 
 	let command= redTool;
-	let args = "-t " + target + " -c " + filePath + " -o " + outName;
+	let args = "-c -t " + target + " -o " + outName + " " + filePath;
 	command = normalFile(command);
 	execCommand(command, args);
 }
@@ -211,7 +211,7 @@ export function redCompileInRelease(fileUri?: vscode.Uri) {
 	filePath = "\"" + filePath + "\"";
 
 	let command= redTool;
-	let args = "-t " + target + " -r " + filePath + " -o " + outName;
+	let args = "-r -t " + target + " -o " + outName + " " + filePath;
 	command = normalFile(command);
 	execCommand(command, args);
 }
@@ -258,7 +258,7 @@ export function redCompileUpdate(fileUri?: vscode.Uri) {
 	filePath = "\"" + filePath + "\"";
 
 	let command= redTool;
-	let args = "-u -c " + filePath + " -o " + outName;
+	let args = "-u -c -o " + outName + " " + filePath;
 	command = normalFile(command);
 	execCommand(command, args);
 }
@@ -287,7 +287,7 @@ function redsCompile(fileUri?: vscode.Uri) {
 	filePath = "\"" + filePath + "\"";
 
 	let command= redTool;
-	let args = "-r " + filePath + " -o " + outName;
+	let args = "-r -o " + outName + " " + filePath;
 	command = normalFile(command);
 	execCommand(command, args);
 }


### PR DESCRIPTION
Fixes red/VScode-extension#41 (all instances of compile commands)