### PR TITLE
Fix command syntax for win32 platform

### DIFF
--- a/src/commandsProvider.ts
+++ b/src/commandsProvider.ts
@@ -38,13 +38,10 @@ function execCommand(command: string, args: string) {
 
 	terminal = terminal ? terminal : vscode.window.createTerminal(`Red`);
 	if (process.platform === 'win32') {
-		text = "cmd /c '";
+		text = "cmd /c \"";
 	}
 	text = text + "\"" + command + "\"";
 	text = text + " " + args;
-	if (process.platform === 'win32') {
-		text = text + "'";
-	}
 	terminal.sendText(text);
 	terminal.show();
 }

--- a/src/commandsProvider.ts
+++ b/src/commandsProvider.ts
@@ -38,7 +38,7 @@ function execCommand(command: string, args: string) {
 
 	terminal = terminal ? terminal : vscode.window.createTerminal(`Red`);
 	if (process.platform === 'win32') {
-		text = "cmd /c \"";
+		text = "cmd --% /c \"";
 	}
 	text = text + "\"" + command + "\"";
 	text = text + " " + args;

--- a/src/commandsProvider.ts
+++ b/src/commandsProvider.ts
@@ -38,7 +38,9 @@ function execCommand(command: string, args: string) {
 
 	terminal = terminal ? terminal : vscode.window.createTerminal(`Red`);
 	if (process.platform === 'win32') {
-		text = "cmd --% /c \"";
+		if (vscode.window.activeTerminal.name !== 'bash') {
+			text = "cmd --% /c \"";
+		}
 	}
 	text = text + "\"" + command + "\"";
 	text = text + " " + args;


### PR DESCRIPTION
The 'Run Current Script' and 'Run Current Script in GUI Console' commands were giving the following error: 'The filename, directory name, or volume label syntax is incorrect.'  Changed from enclosing the command and argument in single quotes, to adding an extra double quote in front of the command.

Reference: https://ss64.com/nt/cmd.html